### PR TITLE
create order requires fee during call to pay for executors reward

### DIFF
--- a/contracts/leverage_trading/src/create_order.rs
+++ b/contracts/leverage_trading/src/create_order.rs
@@ -22,6 +22,9 @@ impl Contract {
     ///
     /// As far as we surpassed gas limit for contract call,
     /// borrow call was separated & made within batch of transaction alongside with Deposit & Add_Liquidity function
+    ///
+    /// Accepts deposit only two times greater than gas for execution in order to cover the execution gas fees and reward an executor
+    #[payable]
     pub fn create_order(
         &mut self,
         order_type: OrderType,
@@ -30,6 +33,9 @@ impl Contract {
         buy_token: AccountId,
         leverage: U128,
     ) -> PromiseOrValue<WBalance> {
+        require!(env::attached_deposit() >= self.view_gas_for_execution() * 2,
+            "Create order should accept deposits two times greater than gas for execution");
+
         let user = env::signer_account_id();
 
         require!(

--- a/contracts/leverage_trading/src/view.rs
+++ b/contracts/leverage_trading/src/view.rs
@@ -1,3 +1,4 @@
+use near_sdk::Gas;
 use crate::big_decimal::{BigDecimal, WRatio};
 use crate::*;
 
@@ -71,8 +72,8 @@ impl Contract {
             let lenpnl = (expect_amount
                 - BigDecimal::from(order.amount)
                 - (BigDecimal::from(order.amount)
-                    * BigDecimal::from(self.protocol_fee / 10_u128.pow(24))))
-            .round_u128();
+                * BigDecimal::from(self.protocol_fee / 10_u128.pow(24))))
+                .round_u128();
 
             PnLView {
                 is_profit: true,
@@ -211,6 +212,11 @@ impl Contract {
             / buy_amount;
 
         liquidation_price.into()
+    }
+
+    /// returns const gas amount required for executing orders: 50 TGas
+    pub fn view_gas_for_execution(&self) -> Balance {
+        Gas::ONE_TERA.0 as Balance  * 50u128
     }
 }
 


### PR DESCRIPTION
create order is payable method, so it requires two times greater of attached deposit than gas of execution to pay an executor for execution an order